### PR TITLE
Use terminfo database for getting colors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/DataDrake/sup
 
 go 1.14
 
-require github.com/DataDrake/flair v0.5.1
+require (
+	github.com/DataDrake/flair v0.5.1
+	github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/DataDrake/flair v0.5.1 h1:JHWOoBRiQGWg+k2bV2Mje2YmDtRjhMj51yDxQkzidWI=
 github.com/DataDrake/flair v0.5.1/go.mod h1:3KgdmkL8eJDbg/HdMwlHkeYH/mpSy/hsQvxYQFp9A/Y=
+github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778 h1:QldyIu/L63oPpyvQmHgvgickp1Yw510KJOqX7H24mg8=
+github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778/go.mod h1:2MuV+tbUrU1zIOPMxZ5EncGwgmMJsa+9ucAQZXxsObs=

--- a/term/util.go
+++ b/term/util.go
@@ -19,19 +19,26 @@ package term
 import (
 	"os"
 	"strings"
+
+	"github.com/xo/terminfo"
 )
 
 // Has256Color checks for 256 color support
 func Has256Color() bool {
-	term := os.Getenv("TERM")
-	switch {
-	case term == "alacritty":
-		return true
-	case strings.Contains(term, "kitty"):
-		return true
-	default:
-		return strings.Contains(term, "256")
+	// Load the current terminfo
+	ti, err := terminfo.LoadFromEnv()
+	if err != nil {
+		return false
 	}
+
+	// Get the colors from the terminfo if set
+	var colors int
+	if colors = ti.Num(terminfo.MaxColors); colors <= 0 {
+		// Colors don't seem to be set, assume basic colors only
+		colors = int(terminfo.ColorLevelBasic)
+	}
+
+	return colors >= 256
 }
 
 // HasUnicode checks for Unicode support


### PR DESCRIPTION
This is a less brittle way of getting terminal colors (and other capabilities) than just checking a list of TERM environment variable entries. This should avoid having to add more checks if more terminals come out that don't just use the old variables, since that isn't really what it's meant to be used for anyway (at least according to some terminal emulator devs).

Adding the dependency kind of sucks, but after looking into it, I think it's a better solution than trying to do it ourselves. It's all a bit arcane, and documentation on reading/decoding terminfo files is... not great.

Change tested with the following terminals:
- gnome-terminal
- Konsole
- Kitty
- Alacritty
- Tilix
- Contour

With and without tmux.